### PR TITLE
Select the first target displayed on the screen

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -49,12 +49,12 @@ angular.module('app.directives', [])
   var process = function(scope, element, attrs) {
     var windowHeight = $window.innerHeight,
         windowTop = $window.scrollY,
-        $activeTarget;
+        $activeTarget = null;
 
     spies.map(function(item, index) {
       var pos = item.offset().top - windowTop;
 
-      if (pos < windowHeight) {
+      if (pos < windowHeight && pos > 0 && $activeTarget == null) {
         $activeTarget = targets.eq(index);
       }
     });


### PR DESCRIPTION
Before the scrollSpy directive was selecting in the navigation the last target that was displayed on the screen.
Now it select the first target that is displayed on the screen.